### PR TITLE
Fix signature usage.

### DIFF
--- a/src/jwt.erl
+++ b/src/jwt.erl
@@ -3,66 +3,61 @@
 
 -include("jwt.hrl").
 
+%%%------------------------------------------------------------------------
+%%% External interface functions
+%%%------------------------------------------------------------------------
+
 encode(Algorithm, Payload, Secret) ->
     encode(Algorithm, Payload, Secret, []).
 
 encode(Algorithm, Payload, Secret, HeaderExtra) ->
     AlgorithmName = atom_to_algorithm(Algorithm),
-    Header = jsx:encode([{typ, <<"JWT">>}, {alg, AlgorithmName}|HeaderExtra]),
-    PayloadJson = jsx:encode(Payload),
-    Signature = get_signature(Algorithm, PayloadJson, Secret),
-    Parts = [Header, PayloadJson, Signature],
-    EncodedParts = [base64url:encode(Item) || Item <- Parts],
-    JwtData = bin_join(EncodedParts, <<".">>),
-    {ok, JwtData}.
+    Header = jsx:encode([{typ, <<"JWT">>},
+                         {alg, AlgorithmName} | HeaderExtra]),
+    HeaderEncoded = base64url:encode(Header),
+    PayloadEncoded = base64url:encode(jsx:encode(Payload)),
+    DataEncoded = <<HeaderEncoded/binary, $., PayloadEncoded/binary>>,
+    Signature = get_signature(Algorithm, DataEncoded, Secret),
+    SignatureEncoded = base64url:encode(Signature),
+    {ok, <<DataEncoded/binary, $., SignatureEncoded/binary>>}.
 
 decode(Data, Secret) when is_binary(Data) ->
-    Parts = binary:split(Data, [<<".">>], [global]),
-    try
-        DecodedParts = [base64url:decode(Item) || Item <- Parts],
-
-        if
-            length(DecodedParts) < 3 ->
-                {error, badtoken};
-            true ->
-                [HeaderJson,BodyRaw,Signature|_Tail] = DecodedParts,
-                Header = jsx:decode(HeaderJson),
-                AlgorithmStr = proplists:get_value(<<"alg">>, Header),
-                Expiration = proplists:get_value(<<"exp">>, Header, noexp),
-                Algorithm = algorithm_to_atom(AlgorithmStr),
-
-                Type = proplists:get_value(<<"typ">>, Header),
-
-                ActualSignature = get_signature(Algorithm, BodyRaw, Secret),
-
-                Jwt = #jwt{typ=Type, body=BodyRaw, alg=Algorithm,
-                           sig=Signature, actual_sig=ActualSignature},
-
-                if
-                    Signature =:= ActualSignature ->
-                        % TODO: leeway
-                        NowSecs = now_secs(),
-                        if Expiration == noexp orelse Expiration > NowSecs ->
+    try binary:split(Data, [<<".">>], [global]) of
+        [HeaderEncoded, PayloadEncoded, SignatureEncoded] ->
+            Header = jsx:decode(base64url:decode(HeaderEncoded)),
+            Type = proplists:get_value(<<"typ">>, Header),
+            AlgorithmStr = proplists:get_value(<<"alg">>, Header),
+            Expiration = proplists:get_value(<<"exp">>, Header, noexp),
+            Algorithm = algorithm_to_atom(AlgorithmStr),
+            DataEncoded = <<HeaderEncoded/binary, $., PayloadEncoded/binary>>,
+            ActualSignature = get_signature(Algorithm, DataEncoded, Secret),
+            Signature = base64url:decode(SignatureEncoded),
+            Payload = jsx:decode(base64url:decode(PayloadEncoded)),
+            Jwt = #jwt{typ=Type, body=Payload, alg=Algorithm,
+                       sig=Signature, actual_sig=ActualSignature},
+            if
+                Signature =:= ActualSignature ->
+                    % TODO: leeway
+                    NowSecs = now_secs(),
+                    if
+                        Expiration == noexp orelse Expiration > NowSecs ->
                             {ok, Jwt};
-                           true ->
-                               {error, {expired, Expiration}}
-                        end;
-
-                    true ->
-                        {error, {badsig, Jwt}}
-                end
-        end
-    catch error:E ->
-              {error, E}
+                        true ->
+                            {error, {expired, Expiration}}
+                    end;
+                true ->
+                    {error, {badsig, Jwt}}
+            end;
+        _ ->
+            {error, badtoken}
+    catch
+        error:E ->
+            {error, E}
     end.
 
-%% private
-
-bin_join(Items, Sep) ->
-    lists:foldl(fun (Val, <<>>) -> Val;
-                    (Val, Accum) ->
-                        <<Accum/binary, Sep/binary, Val/binary>>
-                end, <<>>, Items).
+%%%------------------------------------------------------------------------
+%%% Private functions
+%%%------------------------------------------------------------------------
 
 algorithm_to_atom(<<"HS256">>) -> hs256;
 algorithm_to_atom(<<"HS384">>) -> hs384;
@@ -78,7 +73,7 @@ algorithm_to_crypto_algorithm(hs512) -> sha512.
 
 get_signature(Algorithm, Data, Secret) ->
     CryptoAlg = algorithm_to_crypto_algorithm(Algorithm),
-    crypto:hmac(CryptoAlg, Data, Secret).
+    crypto:hmac(CryptoAlg, Secret, Data).
 
 now_secs() ->
     {MegaSecs, Secs, _MicroSecs} = os:timestamp(),


### PR DESCRIPTION
I needed to change the signature usage to match https://github.com/kato-im/ejwt due to public/standards usage of JWT being different from the previous source code.  The changes also simplify the logic slightly.
