### PR TITLE
- bump jsx version to 'v3.1.0', fix returning maps by default issue

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -1,4 +1,6 @@
 {deps, [
-{jsx,".*",{git,"https://github.com/talentdeficit/jsx.git","v2.8.0"}},{base64url,".*",{git,"https://github.com/dvv/base64url.git","v1.0"}}
-]}.
+        {jsx,".*",{git,"https://github.com/talentdeficit/jsx.git","v3.1.0"}},
+        {base64url,".*",{git,"https://github.com/dvv/base64url.git","v1.0"}}
+       ]}.
+
 {erl_opts, [debug_info,warn_export_vars,warn_shadow_vars,warn_obsolete_guard]}.

--- a/src/jwt.erl
+++ b/src/jwt.erl
@@ -25,10 +25,10 @@ decode(Data, Secret) when is_binary(Data) ->
     try
         case binary:split(Data, [<<".">>], [global]) of
             [HeaderEncoded, PayloadEncoded, SignatureEncoded] ->
-                Header = jsx:decode(base64url:decode(HeaderEncoded)),
-                Type = proplists:get_value(<<"typ">>, Header),
-                AlgorithmStr = proplists:get_value(<<"alg">>, Header),
-                Expiration = proplists:get_value(<<"exp">>, Header, noexp),
+                Header = jsx:decode(base64url:decode(HeaderEncoded), [{return_maps, true}]),
+                Type = maps:get(<<"typ">>, Header, undefined),
+                AlgorithmStr = maps:get(<<"alg">>, Header, undefined),
+                Expiration = maps:get(<<"exp">>, Header, noexp),
                 Algorithm = algorithm_to_atom(AlgorithmStr),
                 DataEncoded = <<HeaderEncoded/binary, $.,
                                 PayloadEncoded/binary>>,
@@ -76,7 +76,7 @@ algorithm_to_crypto_algorithm(hs512) -> sha512.
 
 get_signature(Algorithm, Data, Secret) ->
     CryptoAlg = algorithm_to_crypto_algorithm(Algorithm),
-    crypto:hmac(CryptoAlg, Secret, Data).
+    crypto:mac(hmac, CryptoAlg, Secret, Data).
 
 now_secs() ->
     {MegaSecs, Secs, _MicroSecs} = os:timestamp(),

--- a/test/jwt_SUITE.erl
+++ b/test/jwt_SUITE.erl
@@ -8,15 +8,19 @@ all() ->
      decode_bad_token, decode_bad_token_3_parts, decode_bad_sig,
      decode_expired].
 
-init_per_suite(Config) -> 
+init_per_suite(Config) ->
     Config.
+
+end_per_suite(Config) ->
+    Config.
+
 
 check_encode_decode(Algorithm) ->
     {ok, Jwt} = jwt:encode(Algorithm, [{name, <<"bob">>}, {age, 29}], <<"secret">>),
     {ok, Decoded} = jwt:decode(Jwt, <<"secret">>),
-    Body = jsx:decode(Decoded#jwt.body),
-    Name = proplists:get_value(<<"name">>, Body),
-    Age = proplists:get_value(<<"age">>, Body),
+    Body = jsx:decode(Decoded#jwt.body, [{return_maps, true}]),
+    Name = maps:get(<<"name">>, Body, undefined),
+    Age = maps:get(<<"age">>, Body, undefined),
     <<"JWT">> = Decoded#jwt.typ,
     Algorithm = Decoded#jwt.alg,
     29 = Age,
@@ -58,7 +62,7 @@ decode_bad_token(_) ->
 
 decode_bad_token_3_parts(_) ->
     {error, badarg} = jwt:decode(<<"asd.dsa.lala">>, <<"secret">>),
-    {error, {badmatch, false}} = jwt:decode(<<"a.b.c">>, <<"secret">>).
+    {error, function_clause} = jwt:decode(<<"a.b.c">>, <<"secret">>).
 
 decode_expired(_) ->
     Expiration = jwt:now_secs() - 10,


### PR DESCRIPTION
Because of last version of jsx return map by default (on decode/1, /2) i converted proplists to maps use and add option to ensure maps returned, same for tests. Also changed dependency jsx version to the last one (3.1.0).